### PR TITLE
Apply `SpineContraster` to the color item

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
     "paper-menu-button": "^2.0.0",
     "paper-styles": "^2.0.0",
     "paper-icon-button": "^2.1.0",
-    "iron-icons": "^2.0.1"
+    "iron-icons": "^2.0.1",
+    "spine-contraster": "https://github.com/SpineElements/spine-contraster.git#initial-implementation"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",

--- a/spine-color-picker-item.html
+++ b/spine-color-picker-item.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../spine-contraster/spine-contraster.html">
 
 <!--
  An interactive list item to display one specific color.
@@ -63,7 +64,7 @@
     </template>
 
     <script>{
-        class SpineColorPickerItem extends Polymer.Element {
+        class SpineColorPickerItem extends SpineContraster(Polymer.Element) {
             static get is() {
                 return 'spine-color-picker-item';
             }
@@ -91,6 +92,16 @@
                         type: Boolean,
                         reflectToAttribute: true,
                         observer: '__selectedObserver'
+                    },
+
+                    lightTheme: {
+                        type: Boolean,
+                        reflectToAttribute: true
+                    },
+
+                    darkTheme: {
+                        type: Boolean,
+                        reflectToAttribute: true
                     }
                 }
             }

--- a/test/spine-color-picker-item_test.html
+++ b/test/spine-color-picker-item_test.html
@@ -31,10 +31,6 @@
             expect(element.constructor.is).to.eql('spine-color-picker-item');
         });
 
-        test('should reflect `bgColor` property to the component styles', () => {
-            expect(element.style.background).to.eql(element.bgColor);
-        });
-
         test('should dispatch a proper event upon `selected` property change', () => {
             const spy = sinon.spy();
             element.addEventListener('spine-color-picker-select', spy);
@@ -48,6 +44,16 @@
             element.selected = true;
             const icon = element.shadowRoot.querySelector('iron-icon');
             expect(window.getComputedStyle(icon).visibility).to.eql('visible');
+        });
+
+        test('should reflect `lightTheme` property to the attribute', () => {
+            element.bgColor = '#ffffff';
+            expect(element.hasAttribute('light-theme')).to.eql(true);
+        });
+
+        test('should reflect `darkTheme` property to the attribute', () => {
+            element.bgColor = '#000000';
+            expect(element.hasAttribute('dark-theme')).to.eql(true);
         });
     });
 </script>


### PR DESCRIPTION
This PR applies the `SpineContraster` mixin to the color item to provide a contrast color for the item icon.
Implements #2.

In progress until `SpineContraster` `initial-implementation` branch is not merged to the master.